### PR TITLE
Refactor: Changes eslintrc react version to format specified in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creuna/create-react-app",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": {
     "name": "Asbjorn Hegdahl",
     "email": "asbjorn.hegdahl@creuna.no"

--- a/templates/eslintrc/.eslintrc.json
+++ b/templates/eslintrc/.eslintrc.json
@@ -57,7 +57,7 @@
   },
   "settings": {
     "react": {
-      "version": "^16.3.2"
+      "version": "16.3"
     }
   }
 }


### PR DESCRIPTION
According to the [documentation](https://www.npmjs.com/package/eslint-plugin-react) for `eslint-plugin-react`, react version should not use the package.json-like version syntax but instead just the major and minor version without any special symbols.

The version currently in `.eslintrc.json` does remove the warning but I discovered that at least some rules stop working if `^16.3.0` is used instead of `16.3`. This also makes the `stateless` script in `@creuna/react-scripts` unusable because it uses `eslint-plugin-react` internally.