### PR TITLE
Refactor/browserslist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.2
+
+- Removes `targets` from `@babel/preset-env` options
+- Updates browser support query in `browserslist`
+
 # 5.0.1
 
 - Removes `.creunarc.json` from the scaffolded project.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creuna/create-react-app",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author": {
     "name": "Asbjorn Hegdahl",
     "email": "asbjorn.hegdahl@creuna.no"

--- a/static-files/.babelrc
+++ b/static-files/.babelrc
@@ -8,9 +8,6 @@
       "@babel/preset-env",
       {
         "debug": false,
-        "targets": {
-          "browsers": ["last 2 versions"]
-        },
         "useBuiltIns": "usage"
       }
     ],

--- a/static-files/browserslist
+++ b/static-files/browserslist
@@ -1,1 +1,1 @@
-last 2 versions
+>0.25% in NO


### PR DESCRIPTION
Fixes #48 

Updates `last 2 versions` to [`>0.25% in NO`](https://browserl.ist/?q=%3E0.25%25+in+NO)

The `not ie 11` bit from [here](https://jamie.build/last-2-versions) seemed a little excessive for our use cases. `not op_mini all` is unnecessary with the above query.