### PR TITLE
Feature/directory named plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.3.0
+
+- Adds `directory-named-webpack-plugin` to scaffolded project.
+
 # 5.2.2
 
 - Upgrade all dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 5.3.0
 
+[https://github.com/Creuna-Oslo/create-react-app/pull/65]()
+
 - Adds `directory-named-webpack-plugin` to scaffolded project.
 
 # 5.2.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creuna/create-react-app",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "author": {
     "name": "Asbjorn Hegdahl",
     "email": "asbjorn.hegdahl@creuna.no"

--- a/static-files/source/components/fluid-image/index.js
+++ b/static-files/source/components/fluid-image/index.js
@@ -1,3 +1,0 @@
-import FluidImage from './fluid-image';
-
-export default FluidImage;

--- a/static-files/source/components/image/index.js
+++ b/static-files/source/components/image/index.js
@@ -1,3 +1,0 @@
-import Image from './image';
-
-export default Image;

--- a/static-files/source/components/message/index.js
+++ b/static-files/source/components/message/index.js
@@ -1,3 +1,0 @@
-import Message from './message';
-
-export default Message;

--- a/static-files/source/static-site/pages/example-page/index.js
+++ b/static-files/source/static-site/pages/example-page/index.js
@@ -1,3 +1,0 @@
-import ExamplePage from './example-page';
-
-export default ExamplePage;

--- a/static-files/source/static-site/pages/page-index/index.js
+++ b/static-files/source/static-site/pages/page-index/index.js
@@ -1,3 +1,0 @@
-import PageIndex from './page-index';
-
-export default PageIndex;

--- a/static-files/webpack.config.js
+++ b/static-files/webpack.config.js
@@ -7,6 +7,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin;
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const cssnano = require('cssnano');
+const DirectoryNamedPlugin = require('directory-named-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const StaticSiteGeneratorPlugin = require('static-site-generator-webpack-plugin');
@@ -132,7 +133,16 @@ module.exports = (env = {}, options = {}) => {
       alias: {
         components: path.resolve(__dirname, 'source/components'),
         js: path.resolve(__dirname, 'source/js')
-      }
+      },
+      plugins: [
+        new DirectoryNamedPlugin({
+          honorIndex: true,
+          include: [
+            path.resolve('./source/components'),
+            path.resolve('./source/static-site/pages')
+          ]
+        })
+      ]
     },
     plugins: [
       new MiniCssExtractPlugin({

--- a/static-files/webpack.config.js
+++ b/static-files/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = (env = {}, options = {}) => {
     })(),
     output: (() => {
       const output = {
-        path: path.resolve(__dirname, 'dist'),
+        path: path.resolve('./dist'),
         filename: '[name].[chunkhash].js'
       };
 
@@ -131,8 +131,8 @@ module.exports = (env = {}, options = {}) => {
     resolve: {
       extensions: ['.js', '.jsx', '.scss'],
       alias: {
-        components: path.resolve(__dirname, 'source/components'),
-        js: path.resolve(__dirname, 'source/js')
+        components: path.resolve('./source/components'),
+        js: path.resolve('./source/js')
       },
       plugins: [
         new DirectoryNamedPlugin({

--- a/static-files/webpack.config.js
+++ b/static-files/webpack.config.js
@@ -129,7 +129,7 @@ module.exports = (env = {}, options = {}) => {
       ]
     },
     resolve: {
-      extensions: ['.js', '.jsx', '.scss'],
+      extensions: ['.js', '.jsx'],
       alias: {
         components: path.resolve('./source/components'),
         js: path.resolve('./source/js')

--- a/templates/eslintrc/.eslintrc.json
+++ b/templates/eslintrc/.eslintrc.json
@@ -20,6 +20,7 @@
     "prettier/prettier": [
       "warn",
       {
+        "endOfLine": "auto",
         "singleQuote": true
       }
     ],

--- a/templates/package-json/package.json
+++ b/templates/package-json/package.json
@@ -20,7 +20,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@creuna/codegen": "^0.2.2",
+    "@creuna/codegen": "^0.2.3",
     "@creuna/utils": "^1.1.0",
     "autoprefixer": "^9.1.5",
     "babel-eslint": "^10.0.1",

--- a/templates/package-json/package.json
+++ b/templates/package-json/package.json
@@ -29,6 +29,7 @@
     "copy-webpack-plugin": "^4.3.1",
     "css-loader": "^2.0.0",
     "cssnano": "^4.1.7",
+    "directory-named-webpack-plugin": "^4.0.0",
     "eslint": "^5.5.0",
     "eslint-config-prettier": "^4.0.0",
     "eslint-loader": "^2.0.0",

--- a/templates/readme/README.md
+++ b/templates/readme/README.md
@@ -61,10 +61,10 @@ Also, `directory-named-webpack-plugin` is used to automatically import files tha
 
 ```js
 // <project root>/source/components/some-component/some-component.jsx
-import SomeComponent from "components/some-component";
+import SomeComponent from "components/some-component"; // 'components' alias and directory-named-webpack-plugin
 
 // <project root>/source/js/some-script.js
-import someScript from "js/some-script";
+import someScript from "js/some-script"; // 'js' alias
 ```
 
 The aliases are also included in `jsconfig.json` which makes VS Code resolve the same aliases, giving you autocomplete.

--- a/templates/readme/README.md
+++ b/templates/readme/README.md
@@ -46,31 +46,32 @@ On the backend, use `manifest.json` to look up which files to load and serve.
 
 ### React components
 
-Put React components in `source/components`. It is recommended to have each component in a separate folder, containing a `jsx` file, a `scss` file and an `index.js` file.
-
-If the folder and the `jsx` file have the same name, the component will be included in the generated `app.components.js` file which can be used to render components on a backend (like ReactJS.NET).
+Put React components in `source/components`. If the folder and the `jsx` file have the same name, the component will be included in the generated `app.components.js` file which can be used to render components on a backend (like ReactJS.NET).
 
 When building a static site, `app.components.js` is not generated and `server.js` is not output as part of the build.
 
-### Aliases
+### Import paths
 
-By default, two aliases are included in `webpack.config`:
+`webpack.config` specifies two aliases (under `resolve.alias`) that make importing files easier:
 
 - `components` which resolves to `source/components`
 - `js` which resolves to `source/js`
 
-These aliases allow you to import like this from any `js`/`jsx` file:
+Also, `directory-named-webpack-plugin` is used to automatically import files that have the same name as their containing folder. Examples:
 
-```
-import SomeComponent from 'components/some-component';
-import someScript from 'js/some-script';
+```js
+// <project root>/source/components/some-component/some-component.jsx
+import SomeComponent from "components/some-component";
+
+// <project root>/source/js/some-script.js
+import someScript from "js/some-script";
 ```
 
-These aliases are also included in `jsconfig.json` which makes VS Code resolve the aliases, giving you autocomplete.
+The aliases are also included in `jsconfig.json` which makes VS Code resolve the same aliases, giving you autocomplete.
 
 ### Static Site
 
-All static site pages (`source/static-site/pages`) that have a folder and a component named the same, as well as an `index.js` file, will get a link in the page index (found by default at `/`). You can customize the name, group name, and path of the page in the page's `jsx` file by adding frontmatter to the first line like this:
+All static site pages (`source/static-site/pages`) that have a folder and a component with the same name, will get a link in the page index (found by default at `/`). You can customize the name, group name, and path of the page in the page's `jsx` file by adding frontmatter to the first line like this:
 
 ```js
 /*


### PR DESCRIPTION
Fixes #64 

* Also removes automatic resolution of `.scss` files with webpack, because this seems like a bad idea (Importing scss files in javascript now needs explicit file extension)

The issue with `directory-named-webpack-plugin` on windows has been fixed.