### PR TITLE
Enable go to definition in VS code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.3.1
+
+[https://github.com/Creuna-Oslo/create-react-app/pull/67]()
+
+- Adds `Go to Definition` for VS code.
+
 # 5.3.0
 
 [https://github.com/Creuna-Oslo/create-react-app/pull/65]()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creuna/create-react-app",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "author": {
     "name": "Asbjorn Hegdahl",
     "email": "asbjorn.hegdahl@creuna.no"

--- a/static-files/jsconfig.json
+++ b/static-files/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "jsx": "react",
     "paths": {
       "components/*": ["./source/components/*"],
       "js/*": ["./source/js/*"]


### PR DESCRIPTION
Made CMD/CTRL clicking .jsx imports work.

https://javascriptplayground.com/vscode-go-to-definition-jsx/